### PR TITLE
fix: gitconfig.symlink home path

### DIFF
--- a/git/gitconfig.symlink
+++ b/git/gitconfig.symlink
@@ -3,7 +3,7 @@
 name = ahonn
 email = ahonn95@outlook.com
 [core]
-excludesfile = /Users/ahonn/.gitignore_global
+excludesfile = ~/.gitignore_global
 [includeIf "gitdir:~/Documents/code/"]
 path = ~/Documents/code/.gitconfig
 [push]


### PR DESCRIPTION
use ~ Home path